### PR TITLE
Split the point cloud according to the indexes obtained by the mirrors from bag

### DIFF
--- a/launch/ouster.launch
+++ b/launch/ouster.launch
@@ -25,14 +25,23 @@
    <arg name="down_mirror_points_y"   default ="[-0.051, -0.051, -0.1217, -0.1217]"/>
    <arg name="down_mirror_points_z"   default ="[0.0, 0.0, -0.0842, -0.0842]"/> -->
 
-   <arg name="up_mirror_points_x"     default ="[0.058, 0.058, 0.1477, 0.1477]"/>
+   <!-- Hybrid M600 Mirror Points -->
+   <!-- <arg name="up_mirror_points_x"     default ="[0.058, 0.058, 0.1477, 0.1477]"/>
    <arg name="up_mirror_points_y"     default ="[-0.04391, 0.04391, 0.04391, -0.04391]"/>
    <arg name="up_mirror_points_z"     default ="[0.0, 0.0, 0.0875, 0.0875]"/>
 
    <arg name="down_mirror_points_x"   default ="[0.058, 0.058, 0.1477, 0.1477]"/>
    <arg name="down_mirror_points_y"   default ="[-0.04391, 0.04391, 0.04391, -0.04391]"/>
-   <arg name="down_mirror_points_z"   default ="[0.0, 0.0, -0.0875, -0.0875]"/>
+   <arg name="down_mirror_points_z"   default ="[0.0, 0.0, -0.0875, -0.0875]"/> -->
 
+   <!-- Hybrid Multisensor mockup Mirror Points -->
+   <arg name="up_mirror_points_x"   default ="[-0.067, 0.067, 0.067, -0.067]"/>
+   <arg name="up_mirror_points_y"   default ="[-0.066, -0.066, -0.141, -0.141]"/>
+   <arg name="up_mirror_points_z"   default ="[0.0, 0.0, 0.075, 0.075]"/>
+   
+   <arg name="down_mirror_points_x" default ="[-0.067, 0.067, 0.067, -0.067]"/>
+   <arg name="down_mirror_points_y" default ="[-0.066, -0.066, -0.141, -0.141]"/>
+   <arg name="down_mirror_points_z" default ="[0.0, 0.0, -0.075, -0.075]"/>
 
    <node pkg="ouster_ros" name="os_node" type="os_node" output="screen" required="true">
       <param name="~/lidar_mode"     type="string" value="$(arg lidar_mode)"/>

--- a/launch/split_mirrors_cloud.launch
+++ b/launch/split_mirrors_cloud.launch
@@ -1,0 +1,21 @@
+<launch>
+
+   <!-- Used to publish mirrors markers -->
+   <!-- Hybrid Multisensor mockup Mirror Points -->
+   <arg name="up_mirror_points_x"     default ="[0.058, 0.058, 0.1477, 0.1477]"/>
+   <arg name="up_mirror_points_y"     default ="[-0.04391, 0.04391, 0.04391, -0.04391]"/>
+   <arg name="up_mirror_points_z"     default ="[0.0, 0.0, 0.0875, 0.0875]"/>
+
+   <arg name="down_mirror_points_x"   default ="[0.058, 0.058, 0.1477, 0.1477]"/>
+   <arg name="down_mirror_points_y"   default ="[-0.04391, 0.04391, 0.04391, -0.04391]"/>
+   <arg name="down_mirror_points_z"   default ="[0.0, 0.0, -0.0875, -0.0875]"/>
+
+    <node pkg="ouster_ros" name="os_split_cloud_node" type="os_split_cloud_node" output="screen" required="false">
+        <rosparam param="/up_mirror_points_x"   subst_value="True">$(arg up_mirror_points_x)</rosparam>
+        <rosparam param="/up_mirror_points_y"   subst_value="True">$(arg up_mirror_points_y)</rosparam>
+        <rosparam param="/up_mirror_points_z"   subst_value="True">$(arg up_mirror_points_z)</rosparam>
+        <rosparam param="/down_mirror_points_x" subst_value="True">$(arg down_mirror_points_x)</rosparam>
+        <rosparam param="/down_mirror_points_y" subst_value="True">$(arg down_mirror_points_y)</rosparam>
+        <rosparam param="/down_mirror_points_z" subst_value="True">$(arg down_mirror_points_z)</rosparam>
+    </node>
+</launch>

--- a/src/mirror_markers.cpp
+++ b/src/mirror_markers.cpp
@@ -14,7 +14,7 @@ MirrorMarkers::MirrorMarkers(const double &mirror_angle, const double &mirror_di
    initializeMarkers();
 }
 
-MirrorMarkers::MirrorMarkers(std::vector<Eigen::Vector3d> &up_points, std::vector<Eigen::Vector3d> &down_points)
+MirrorMarkers::MirrorMarkers(const std::vector<Eigen::Vector3d> &up_points, const std::vector<Eigen::Vector3d> &down_points)
 {
    _up_points       = up_points;
    _down_points     = down_points;

--- a/src/mirror_markers.h
+++ b/src/mirror_markers.h
@@ -16,7 +16,7 @@ class MirrorMarkers
   public:
    MirrorMarkers(const double &mirror_angle, const double &mirror_distance_m, const double &w_mirror_m,
                  const double &h_mirror_m);
-   MirrorMarkers(std::vector<Eigen::Vector3d> &up_points, std::vector<Eigen::Vector3d> &down_points);
+   MirrorMarkers(const std::vector<Eigen::Vector3d> &up_points, const std::vector<Eigen::Vector3d> &down_points);
 
    virtual ~MirrorMarkers();
 


### PR DESCRIPTION
A roslaunch has been added to be able to execute the node that is in responsible of splitting the point cloud from the indices obtained by the mirrors from a rosbag.

In addition, it has been managed when the parameters of the mirrors aren't received and the markers are not published. In this way, the node can be executed without the need to pass these parameters to it.